### PR TITLE
Added get-league-patch action

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,5 @@ Join the [Riot Games Third Party Party Developer Community](https://discordapp.c
 * [Setup League Client](https://github.com/marketplace/actions/setup-league-client) - A GitHub Action for setting up LCU on a Windows runner.
 
 * [Download League of Legends Data Dragon](https://github.com/marketplace/actions/download-league-of-legends-data-dragon) - A GitHub Action for downloading the Data Dragon on a runner.
+
+* [Get League Patch](https://github.com/marvinscham/get-league-patch) - A GitHub Action saving the latest patch into a variable.


### PR DESCRIPTION
[get-league-patch](https://github.com/marvinscham/get-league-patch) is a GitHub action that allows you to grab the latest release number like `12.14` from Data Dragon to a variable.

My use case is to keep the patch badge at [Disenchanter](https://github.com/marvinscham/disenchanter) up to date by [creating a PR](https://github.com/marvinscham/disenchanter/blob/main/.github/workflows/league-patch.yml) that requires testing the tool on the new patch.

