### PR TITLE
Added "go-lcu" to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Join the [Riot Games Third Party Developer Community](https://discordapp.com/inv
 
 * [RiftExplorer](https://github.com/Pupix/rift-explorer) - Electron application to explore the LCU API.
 
+* [go-lcu](https://github.com/ImOlli/go-lcu) - Go Library to automatically retrieve the port and token of the LCU and wrap it behind a reverse proxy.
+
 ## DevOps Tools
 
 * [Setup League Client](https://github.com/marketplace/actions/setup-league-client) - A GitHub Action for setting up LCU on a Windows runner.


### PR DESCRIPTION
Added "go-lcu" a small go library to automatically retrieve the port and auth token of the lcu. You can also use the library to start a proxy to wrap things like self-signed certificate, cors policy and authentication behind it.