### PR TITLE
Add YearIn.LoL

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Join the [Riot Games Third Party Developer Community](https://discordapp.com/inv
 
 * [Skin Explorer](https://www.skinexplorer.lol) - Browse through League of Legends splash art from your browser.
 
+* [YearIn.LoL](https://yearin.lol) - A yearly recap that presents your League of Legends stats in a fun and entertaining way. 
+
 ## Content Creation
 
 * [League Director](https://github.com/RiotGames/leaguedirector) - Official tool for making advanced League of Legends replays.


### PR DESCRIPTION
Add YearIn.LoL, a yearly recap site for League of Legends. 
I hope it is right in the external-apps category. 