### PR TITLE
Add Weered to External Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ Join the [Riot Games Third Party Developer Community](https://discordapp.com/inv
 
 * [ytLegends](https://github.com/0adri3n/ytLegends) - A League Of Legends overlay to play YouTube videos in-game.
 
-* [Weered](https://weered.ca) - Lobby and voice-room platform for League communities; pulls summoner profiles, ranked leaderboards, and free rotation via the Riot API.
-
 ## External Apps
 
 * [Clean Cuts](https://blossomishymae.github.io/clean-cuts/) - Provides League of Legends game data in a human-friendly format.
@@ -112,6 +110,8 @@ Join the [Riot Games Third Party Developer Community](https://discordapp.com/inv
 * [LeagueStats](https://leaguestats.gg/) - Website that provides global complete data for all League of Legends summoners.
 
 * [LeagueStreams.gg](https://leaguestreams.gg) - Browse through Live League of Legends Streams with in-Game Informations or watch thousands of VODs by Champion, Lane or even Opponent.
+
+* [Weered](https://weered.ca) - Lobby and voice-room platform for League communities; pulls summoner profiles, ranked leaderboards, and free rotation via the Riot API.
 
 ## Content Creation
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Join the [Riot Games Third Party Developer Community](https://discordapp.com/inv
 
 * [ytLegends](https://github.com/0adri3n/ytLegends) - A League Of Legends overlay to play YouTube videos in-game.
 
+* [Weered](https://weered.ca) - Lobby and voice-room platform for League communities; pulls summoner profiles, ranked leaderboards, and free rotation via the Riot API.
+
 ## External Apps
 
 * [Clean Cuts](https://blossomishymae.github.io/clean-cuts/) - Provides League of Legends game data in a human-friendly format.


### PR DESCRIPTION
Adds Weered, a community platform that uses the Riot API for summoner lookup, ranked leaderboards, and the free champion rotation.

<img width="1906" height="952" alt="LoL" src="https://github.com/user-attachments/assets/485be895-f4c0-41e3-ade6-82d3896921a7" />

<img width="1907" height="954" alt="LoL2" src="https://github.com/user-attachments/assets/936c11cf-dc12-4124-8f3c-1fd4aec7f3dc" />

