### PR TITLE
Add Hextech Secretary (海克斯小秘书) to External Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Join the [Riot Games Third Party Developer Community](https://discordapp.com/inv
 
 * [Weered](https://weered.ca) - Lobby and voice-room platform for League communities; pulls summoner profiles, ranked leaderboards, and free rotation via the Riot API.
 
+* [Hextech Secretary 海克斯小秘书](https://aramkit.cdqyfdbymn.me/) - An ARAM Mayhem (ARAM with Hextech augments) guide website with champion win-rate tier list, builds, skill orders and augment recommendations, aggregated from three stats sources and available in 12 languages.
+
 ## Content Creation
 
 * [League Director](https://github.com/RiotGames/leaguedirector) - Official tool for making advanced League of Legends replays.


### PR DESCRIPTION
Adds **Hextech Secretary (海克斯小秘书)** — an ARAM Mayhem (ARAM with Hextech augments) guide website, placed under External Apps alongside other stats sites like ARAM Zone and LoL Society:

- Champion win-rate tier list (all 173 champions), core builds and skill orders
- Hextech augment recommendations per champion, plus a reverse index of which champions recommend each augment
- Available in 12 languages (zh, en, ja, ko, de, fr, es, pt-BR, vi, tr, pl, zh-TW); champion/item/augment names localized via Riot's Data Dragon
- Static site with nightly-updated stats aggregated from three telemetry sources

I'm the author of the site. Happy to adjust the entry or move it to a more suitable section if needed.
